### PR TITLE
Run validator after segment/node change

### DIFF
--- a/src/login.js
+++ b/src/login.js
@@ -1278,14 +1278,13 @@ function F_LOGIN()
 	});
 
 	// monitor segments and nodes changes
-	// TODO: fix me to WMo.segments.on
-	// WMo.segments.events.on({
-	//     "objectsadded": onSegmentsAdded,
-	//     "objectschanged": onSegmentsChanged,
-	//     "objectsremoved": onSegmentsRemoved,
-	// });
-	// WMo.nodes.events.on({
-	//     "objectschanged": onNodesChanged,
-	//     "objectsremoved": onNodesRemoved,
-	// });
+	WMo.segments.on({
+	    "objectsadded": onSegmentsAdded,
+	    "objectschanged": onSegmentsChanged,
+	    "objectsremoved": onSegmentsRemoved,
+	});
+	WMo.nodes.on({
+	    "objectschanged": onNodesChanged,
+	    "objectsremoved": onNodesRemoved,
+	});
 }


### PR DESCRIPTION
Fixes the behaviour of Validator to trigger after segments or nodes have been changed in the editor.