### PR TITLE
Fixes opening the translations and available rules windows

### DIFF
--- a/src/report.js
+++ b/src/report.js
@@ -741,8 +741,10 @@ function F_SHOWREPORT(reportFormat) {
 	}
 	// opens new browser window
 	function openWindow(data) {
-		UW.open("data:text/html;charset=UTF-8," + encodeURIComponent(data),
-			"_blank");
+		var nw = UW.open("", "_blank");
+		nw.document.write(data);
+		// UW.open("data:text/html;charset=UTF-8," + encodeURIComponent(data),
+		// 	"_blank");
 	}
 	// opens new browser window for final report
 	/** @param {string=} title */


### PR DESCRIPTION
Under settings -> Info there are buttons to show the current enabled/disabled rules and a wizard to create a translation. These opened and closed instantly in Chrome. This fixes that.