### PR TITLE
Adding speed limit checks -> Unverified, missing and possible invalid

### DIFF
--- a/meta/wme-externs.js
+++ b/meta/wme-externs.js
@@ -350,6 +350,7 @@ var W = {
 	}, // selectionManager
 	model: {
 		isLeftHand: false,
+		isImperial: false,
 		events: { on: 0, un: 0 },
 		actionManager: {
 			events: { on: 0, un: 0 },

--- a/src/validate.js
+++ b/src/validate.js
@@ -2457,7 +2457,11 @@ function F_VALIDATE(disabledHL) {
 					// Verify speed limit
 					if(forwardSpeed){
 						options = getCheckOptions(214, countryCode);
-						if (!options[CO_REGEXP].test(forwardSpeed)
+						var check_speed = forwardSpeed;
+						if (Wa.model.isImperial){
+							check_speed = Math.round(forwardSpeed / 1.609);
+						}
+						if (!options[CO_REGEXP].test(check_speed)
 							&& isLimitOk(214)
 							&& address.isOkFor(214))
 							segment.report(214);
@@ -2477,7 +2481,11 @@ function F_VALIDATE(disabledHL) {
 					// Verify speed limit
 					if(reverseSpeed){
 						options = getCheckOptions(215, countryCode);
-						if (!options[CO_REGEXP].test(reverseSpeed)
+						var check_speed = reverseSpeed;
+						if (Wa.model.isImperial){
+							check_speed = Math.round(reverseSpeed / 1.609);
+						}
+						if (!options[CO_REGEXP].test(check_speed)
 							&& isLimitOk(215)
 							&& address.isOkFor(215))
 							segment.report(215);

--- a/src/validate.js
+++ b/src/validate.js
@@ -1659,6 +1659,18 @@ function F_VALIDATE(disabledHL) {
 		var reverseSpeed = segment.$revMaxSpeed;
 		var forwardSpeedUnverified = segment.$fwdMaxSpeedUnverified;
 		var reverseSpeedUnverified = segment.$fwdMaxSpeedUnverified;
+		var speedConversionFactor = 1;  // default to metric
+		var speedMultipleFactor = 10;   // default to limits being set in multiples of 10
+		// check for MPH countries
+		if ((country == "United Kingdom") ||
+			(country == "Jersey") ||
+			(country == "Guernsey") ||
+			(country == "United States"))
+			speedConversionFactor = 1.609;
+		// countries with multiple of 5
+		if ((country == "United States") ||
+			(country == "Guernsey"))
+			speedMultipleFactor = 5;
 
 		var hasRestrictions = segment.$hasRestrictions;
 
@@ -2454,6 +2466,23 @@ function F_VALIDATE(disabledHL) {
 						&& isLimitOk(212)
 						&& address.isOkFor(212))
 						segment.report(212);
+					// Verify speed limit
+					if(!isNaN(forwardSpeed) && forwardSpeed !== null){
+						var check_speed = Math.round(forwardSpeed / speedConversionFactor);
+						var skip_check = false;
+						if((country === 'Germany' && check_speed === 7)
+							|| (country === 'Netherlands' && check_speed === 15)
+							|| (country === 'Netherlands' && check_speed === 25)){
+							// Handle certain exceptions
+							skip_check = true;
+						}
+						if (!skip_check){
+							if (check_speed % speedMultipleFactor !== 0
+								&& isLimitOk(214)
+								&& address.isOkFor(214))
+								segment.report(214);
+						}
+					}
 				}
 
 				if (DIR_BA === direction || DIR_TWO == direction) {
@@ -2466,6 +2495,23 @@ function F_VALIDATE(disabledHL) {
 						&& isLimitOk(213)
 						&& address.isOkFor(213))
 						segment.report(213);
+					// Verify speed limit
+					if(!isNaN(reverseSpeed) && reverseSpeed !== null){
+						var check_speed = Math.round(reverseSpeed / speedConversionFactor);
+						var skip_check = false;
+						if((country === 'Germany' && check_speed === 7)
+							|| (country === 'Netherlands' && check_speed === 15)
+							|| (country === 'Netherlands' && check_speed === 25)){
+							// Handle certain exceptions
+							skip_check = true;
+						}
+						if (!skip_check){
+							if (check_speed % speedMultipleFactor !== 0
+								&& isLimitOk(215)
+								&& address.isOkFor(215))
+								segment.report(215);
+						}
+					}
 				}
 			}// global speed limit check
 

--- a/src/validate.js
+++ b/src/validate.js
@@ -2442,6 +2442,34 @@ function F_VALIDATE(disabledHL) {
 			} // public connection
 
 			// GROUP isDrivable
+			// global speed limit check
+			if (RR_SERVICE < typeRank){
+				if (DIR_AB === direction || DIR_TWO === direction) {
+					if (forwardSpeedUnverified
+						&& isLimitOk(210)
+						&& address.isOkFor(210))
+						segment.report(210);
+
+					if ((isNaN(forwardSpeed) || forwardSpeed === null || forwardSpeed === 0)
+						&& isLimitOk(212)
+						&& address.isOkFor(212))
+						segment.report(212);
+				}
+
+				if (DIR_BA === direction || DIR_TWO == direction) {
+					if (reverseSpeedUnverified
+						&& isLimitOk(211)
+						&& address.isOkFor(211))
+						segment.report(211);
+
+					if ((isNaN(reverseSpeed) || reverseSpeed === null || reverseSpeed === 0)
+						&& isLimitOk(213)
+						&& address.isOkFor(213))
+						segment.report(213);
+				}
+			}// global speed limit check
+
+			// GROUP isDrivable
 			if (DIR_UNKNOWN === direction
 				&& isLimitOk(25)
 				&& address.isOkFor(25))

--- a/src/validate.js
+++ b/src/validate.js
@@ -2444,9 +2444,6 @@ function F_VALIDATE(disabledHL) {
 			// GROUP isDrivable
 			// global speed limit check
 			if (RR_SERVICE < typeRank){
-				var speedConversionFactor = parseInt(trS("speed.conversionfactor"), 10);
-				var speedMultipleFactor = parseInt(trS("speed.multiplefactor"), 10);
-				var speedExceptions = trS("speed.exceptions").split(",").map(Number);
 				if (DIR_AB === direction || DIR_TWO === direction) {
 					if (forwardSpeedUnverified
 						&& isLimitOk(210)
@@ -2459,17 +2456,11 @@ function F_VALIDATE(disabledHL) {
 						segment.report(212);
 					// Verify speed limit
 					if(forwardSpeed){
-						var check_speed = Math.round(forwardSpeed / speedConversionFactor);
-						var skip_check = false;
-						if(speedExceptions.includes(check_speed))
-							skip_check = true;
-
-						if (!skip_check){
-							if (check_speed % speedMultipleFactor !== 0
-								&& isLimitOk(214)
-								&& address.isOkFor(214))
-								segment.report(214);
-						}
+						options = getCheckOptions(214, countryCode);
+						if (!options[CO_REGEXP].test(forwardSpeed)
+							&& isLimitOk(214)
+							&& address.isOkFor(214))
+							segment.report(214);
 					}
 				}
 
@@ -2485,17 +2476,11 @@ function F_VALIDATE(disabledHL) {
 						segment.report(213);
 					// Verify speed limit
 					if(reverseSpeed){
-						var check_speed = Math.round(reverseSpeed / speedConversionFactor);
-						var skip_check = false;
-						if(speedExceptions.includes(check_speed))
-							skip_check = true;
-
-						if (!skip_check){
-							if (check_speed % speedMultipleFactor !== 0
-								&& isLimitOk(215)
-								&& address.isOkFor(215))
-								segment.report(215);
-						}
+						options = getCheckOptions(215, countryCode);
+						if (!options[CO_REGEXP].test(reverseSpeed)
+							&& isLimitOk(215)
+							&& address.isOkFor(215))
+							segment.report(215);
 					}
 				}
 			}// global speed limit check

--- a/src/validate.js
+++ b/src/validate.js
@@ -1659,18 +1659,6 @@ function F_VALIDATE(disabledHL) {
 		var reverseSpeed = segment.$revMaxSpeed;
 		var forwardSpeedUnverified = segment.$fwdMaxSpeedUnverified;
 		var reverseSpeedUnverified = segment.$fwdMaxSpeedUnverified;
-		var speedConversionFactor = 1;  // default to metric
-		var speedMultipleFactor = 10;   // default to limits being set in multiples of 10
-		// check for MPH countries
-		if ((country == "United Kingdom") ||
-			(country == "Jersey") ||
-			(country == "Guernsey") ||
-			(country == "United States"))
-			speedConversionFactor = 1.609;
-		// countries with multiple of 5
-		if ((country == "United States") ||
-			(country == "Guernsey"))
-			speedMultipleFactor = 5;
 
 		var hasRestrictions = segment.$hasRestrictions;
 
@@ -2456,6 +2444,9 @@ function F_VALIDATE(disabledHL) {
 			// GROUP isDrivable
 			// global speed limit check
 			if (RR_SERVICE < typeRank){
+				var speedConversionFactor = parseInt(trS("speed.conversionfactor"), 10);
+				var speedMultipleFactor = parseInt(trS("speed.multiplefactor"), 10);
+				var speedExceptions = trS("speed.exceptions").split(",").map(Number);
 				if (DIR_AB === direction || DIR_TWO === direction) {
 					if (forwardSpeedUnverified
 						&& isLimitOk(210)
@@ -2470,12 +2461,9 @@ function F_VALIDATE(disabledHL) {
 					if(forwardSpeed){
 						var check_speed = Math.round(forwardSpeed / speedConversionFactor);
 						var skip_check = false;
-						if((country === 'Germany' && check_speed === 7)
-							|| (country === 'Netherlands' && check_speed === 15)
-							|| (country === 'Netherlands' && check_speed === 25)){
-							// Handle certain exceptions
+						if(speedExceptions.includes(check_speed))
 							skip_check = true;
-						}
+
 						if (!skip_check){
 							if (check_speed % speedMultipleFactor !== 0
 								&& isLimitOk(214)
@@ -2499,12 +2487,9 @@ function F_VALIDATE(disabledHL) {
 					if(reverseSpeed){
 						var check_speed = Math.round(reverseSpeed / speedConversionFactor);
 						var skip_check = false;
-						if((country === 'Germany' && check_speed === 7)
-							|| (country === 'Netherlands' && check_speed === 15)
-							|| (country === 'Netherlands' && check_speed === 25)){
-							// Handle certain exceptions
+						if(speedExceptions.includes(check_speed))
 							skip_check = true;
-						}
+
 						if (!skip_check){
 							if (check_speed % speedMultipleFactor !== 0
 								&& isLimitOk(215)

--- a/src/validate.js
+++ b/src/validate.js
@@ -2462,12 +2462,12 @@ function F_VALIDATE(disabledHL) {
 						&& address.isOkFor(210))
 						segment.report(210);
 
-					if ((isNaN(forwardSpeed) || forwardSpeed === null || forwardSpeed === 0)
+					if (!forwardSpeed
 						&& isLimitOk(212)
 						&& address.isOkFor(212))
 						segment.report(212);
 					// Verify speed limit
-					if(!isNaN(forwardSpeed) && forwardSpeed !== null){
+					if(forwardSpeed){
 						var check_speed = Math.round(forwardSpeed / speedConversionFactor);
 						var skip_check = false;
 						if((country === 'Germany' && check_speed === 7)
@@ -2491,12 +2491,12 @@ function F_VALIDATE(disabledHL) {
 						&& address.isOkFor(211))
 						segment.report(211);
 
-					if ((isNaN(reverseSpeed) || reverseSpeed === null || reverseSpeed === 0)
+					if (!reverseSpeed
 						&& isLimitOk(213)
 						&& address.isOkFor(213))
 						segment.report(213);
 					// Verify speed limit
-					if(!isNaN(reverseSpeed) && reverseSpeed !== null){
+					if(reverseSpeed){
 						var check_speed = Math.round(reverseSpeed / speedConversionFactor);
 						var skip_check = false;
 						if((country === 'Germany' && check_speed === 7)


### PR DESCRIPTION
When a segment is a type of Street up to Freeway (so excluding private roads and such):

- Check if a segment has a unverified speed limit set from A to B (when needed)
- Check if a segment has a unverified speed limit set from B to A (when needed)
- Check if a segment has no speed limit set from A to B (when needed)
- Check if a segment has no speed limit set from B to A (when needed)

Also implements the functionality found in URO+ to check for possible invalid speed limits. See the function uroGetLocalisedSpeedString in URO+ for the original implementation.