### PR TITLE
Fix street isolated by ramps

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -1514,7 +1514,8 @@ function F_VALIDATE(disabledHL) {
 				var otherSegment = seg.$nodeA.$otherSegments[i];
 				if (ignoreSegment && otherSegment === ignoreSegment)
 					continue;
-				if (otherSegment.$rawSegment.isRoutable()) {
+				// Remember; ramps are public too, just not endpoint routable.
+				if (otherSegment.$rawSegment.isRoutable() || RT_RAMP === otherSegment.$type) {
 					foundPublicConnection = true;
 					break;
 				}
@@ -1525,7 +1526,7 @@ function F_VALIDATE(disabledHL) {
 				var otherSegment = seg.$nodeB.$otherSegments[i];
 				if (ignoreSegment && otherSegment === ignoreSegment)
 					continue;
-				if (otherSegment.$rawSegment.isRoutable()) {
+				if (otherSegment.$rawSegment.isRoutable() || RT_RAMP === otherSegment.$type) {
 					foundPublicConnection = true;
 					break;
 				}


### PR DESCRIPTION
If a street is surrounded by ramps, it should not be flagged as isolated. Example link; https://www.waze.com/nl/editor?env=usa&lon=-95.59878&lat=33.66108&zoom=7&segments=66499080,66499061

This fixes this issue by checking if a segment is connected to any ramp. If see, mark it as public accesable.