### PR TITLE
Fixes getting MPH vs KPH based on segment

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -143,8 +143,14 @@ function getDirection(seg) {
 	return (seg.attributes.fwdDirection ? 1 : 0) + (seg.attributes.revDirection ? 2 : 0);
 };
 
-function getLocalizedValue(val) {
+function getLocalizedValue(val, country) {
 	var ipu = OpenLayers.INCHES_PER_UNIT;
-	return W.model.isImperial ?
+	var mph = false;
+	if ((country == "United Kingdom") ||
+		(country == "Jersey") ||
+		(country == "Guernsey") ||
+		(country == "United States"))
+		mph = true;
+	return mph ?
 		Math.round(val * ipu["km"] / ipu["mi"]) : val;
 }

--- a/src/validate.js
+++ b/src/validate.js
@@ -545,9 +545,9 @@ function F_VALIDATE(disabledHL) {
 		});
 		this.$restrictionsLen = attrs.restrictions.length;
 		// set speedlimits
-		this.$fwdMaxSpeed = getLocalizedValue(+attrs.fwdMaxSpeed);
+		this.$fwdMaxSpeed = getLocalizedValue(+attrs.fwdMaxSpeed, this.$address.$country);
 		this.$fwdMaxSpeedUnverified = attrs.fwdMaxSpeedUnverified;
-		this.$revMaxSpeed = getLocalizedValue(+attrs.revMaxSpeed);
+		this.$revMaxSpeed = getLocalizedValue(+attrs.revMaxSpeed, this.$address.$country);
 		this.$revMaxSpeedUnverified = attrs.revMaxSpeedUnverified;
 
 		this.$flags = seg.getFlagAttributes();


### PR DESCRIPTION
Example PL: https://www.waze.com/nl/editor?env=usa&lon=-99.50151&lat=27.49976&zoom=5

This situation has the issue that a editor can edit in a country which is imperial (the US) and metrical (Mexico) what causes Validator to flag segments as having the wrong speed. This fixes that by looking at the country of a segment and converting the speed to mph or not according to a exception list.

The list of countries using MPH is a given and can be hardcoded imo.

This change was discused in #79