### PR TITLE
Fix missing in layer selection using part of WazeWrap

### DIFF
--- a/meta/meta-begin.js
+++ b/meta/meta-begin.js
@@ -5,6 +5,7 @@
 // @match               https://beta.waze.com/*editor*
 // @match               https://www.waze.com/*editor*
 // @exclude             https://www.waze.com/*user/*editor/*
+// @require             https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js
 // @grant               none
 // @icon                https://raw.githubusercontent.com/WMEValidator/release/master/img/WV-icon96.png
 // @namespace           a

--- a/meta/meta-begin.js
+++ b/meta/meta-begin.js
@@ -5,7 +5,6 @@
 // @match               https://beta.waze.com/*editor*
 // @match               https://www.waze.com/*editor*
 // @exclude             https://www.waze.com/*user/*editor/*
-// @require             https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js
 // @grant               none
 // @icon                https://raw.githubusercontent.com/WMEValidator/release/master/img/WV-icon96.png
 // @namespace           a

--- a/meta/wme-externs.js
+++ b/meta/wme-externs.js
@@ -27,22 +27,21 @@ var I18n = {
 			layers: {
 				name: {},
 			},
+			keyboard_shortcuts: {
+				groups: {
+					description: "",
+					members: { },
+				},
+			},
 		},
 	},
 	currentLocale: function () { },
 }
 
 ///////////////////////////////////////////////////////////////////////////
-// WazeWrap Namespace
+// sessionStorage Namespace
 /** @type {Object} */
-var WazeWrap = {
-	Interface: {
-		Shortcut: {
-			add:  function () { },
-		},
-		AddLayerCheckbox: function(group, checkboxText, checked, callback) { },
-	}
-}
+var sessionStorage = { }
 
 ///////////////////////////////////////////////////////////////////////////
 // OpenLayers Namespace
@@ -153,9 +152,9 @@ var Waze = {
 	Util: {
 		localStorage: {
 			get: function (a) { },
-			set: function (a, b) { }
-		}
-	}
+			set: function (a, b) { },
+		},
+	},
 };
 /** @constructor */
 Waze.NODE = function () {
@@ -332,9 +331,16 @@ var W = {
 		getAppRegionCode: function () { },
 	},
 	accelerators: {
+		_registerShortcuts: function(a) { },
 		events: {
 			register: function (a, b, c) { },
+			listeners: { 
+				func: function() { },
+				obj: { },
+			},
 		},
+		Groups: { },
+		Actions: { },
 	},
 	MapLayers: {
 		layerVisibilityBitmask: {}

--- a/meta/wme-externs.js
+++ b/meta/wme-externs.js
@@ -33,6 +33,17 @@ var I18n = {
 }
 
 ///////////////////////////////////////////////////////////////////////////
+// WazeWrap Namespace
+/** @type {Object} */
+var WazeWrap = {
+	Interface: {
+		Shortcut: {
+			add:  function () { },
+		}
+	}
+}
+
+///////////////////////////////////////////////////////////////////////////
 // OpenLayers Namespace
 /** @type {Object} */
 var OpenLayers = {

--- a/meta/wme-externs.js
+++ b/meta/wme-externs.js
@@ -39,7 +39,8 @@ var WazeWrap = {
 	Interface: {
 		Shortcut: {
 			add:  function () { },
-		}
+		},
+		AddLayerCheckbox: function(group, checkboxText, checked, callback) { },
 	}
 }
 

--- a/src/basic.js
+++ b/src/basic.js
@@ -738,3 +738,12 @@ function onChangeIsImperial() {
 	_RT.$isMapChanged = true;
 	async(F_LOGIN);
 }
+
+/**
+* Toggle WME Validator from shortcut
+*/
+function onToggleValidator(){
+	// switch Validator on/off
+	_RT.$switchValidator = true;
+	async(F_UPDATEUI);
+}

--- a/src/login.js
+++ b/src/login.js
@@ -1217,6 +1217,9 @@ function F_LOGIN() {
 	$('#user-tabs+div.tab-content').append(
 		'<div class="tab-pane" id="sidepanel-' + ID_PREFIX + '"></div>'
 	);
+	// Create Shortcut
+	new WazeWrap.Interface.Shortcut(GL_LAYERACCEL, 'Toggle WME Validator',
+		'wmevalidator', 'WME Validator', GL_LAYERSHORTCUT, onToggleValidator, null).add();
 	// append user interface after the details or ad the bottom
 	_THUI.appendUI(document.getElementById("sidepanel-" + ID_PREFIX),
 		_UI, "i" + ID_PREFIX);

--- a/src/login.js
+++ b/src/login.js
@@ -1220,6 +1220,9 @@ function F_LOGIN() {
 	// Create Shortcut
 	new WazeWrap.Interface.Shortcut(GL_LAYERACCEL, 'Toggle WME Validator',
 		'wmevalidator', 'WME Validator', GL_LAYERSHORTCUT, onToggleValidator, null).add();
+
+	new WazeWrap.Interface.AddLayerCheckbox("issues", GL_LAYERNAME, _UI.pSettings.pScanner.oHLReported.CHECKED, onToggleValidator)
+
 	// append user interface after the details or ad the bottom
 	_THUI.appendUI(document.getElementById("sidepanel-" + ID_PREFIX),
 		_UI, "i" + ID_PREFIX);

--- a/src/login.js
+++ b/src/login.js
@@ -1217,11 +1217,8 @@ function F_LOGIN() {
 	$('#user-tabs+div.tab-content').append(
 		'<div class="tab-pane" id="sidepanel-' + ID_PREFIX + '"></div>'
 	);
-	// Create Shortcut
-	new WazeWrap.Interface.Shortcut(GL_LAYERACCEL, 'Toggle WME Validator',
-		'wmevalidator', 'WME Validator', GL_LAYERSHORTCUT, onToggleValidator, null).add();
-
-	new WazeWrap.Interface.AddLayerCheckbox("issues", GL_LAYERNAME, _UI.pSettings.pScanner.oHLReported.CHECKED, onToggleValidator)
+	// Add layer to the layer selector see helpers.js
+	AddLayerCheckbox("issues", GL_LAYERNAME, _UI.pSettings.pScanner.oHLReported.CHECKED, onToggleValidator)
 
 	// append user interface after the details or ad the bottom
 	_THUI.appendUI(document.getElementById("sidepanel-" + ID_PREFIX),

--- a/src/other.js
+++ b/src/other.js
@@ -434,7 +434,7 @@ function F_INIT() {
 	WM = nW.map;
 	WMo = nW.model;
 	WC = nW.controller;
-	if (!Wa || !WLM || !WSM || !WM || !WMo || !WC || !WazeWrap || !$("#user-tabs")) {
+	if (!Wa || !WLM || !WSM || !WM || !WMo || !WC || !$("#user-tabs")) {
 		log("waiting for WME...")
 		async(F_INIT, null, 1e3);
 		return;

--- a/src/other.js
+++ b/src/other.js
@@ -434,7 +434,7 @@ function F_INIT() {
 	WM = nW.map;
 	WMo = nW.model;
 	WC = nW.controller;
-	if (!Wa || !WLM || !WSM || !WM || !WMo || !WC || !$("#user-tabs")) {
+	if (!Wa || !WLM || !WSM || !WM || !WMo || !WC || !WazeWrap || !$("#user-tabs")) {
 		log("waiting for WME...")
 		async(F_INIT, null, 1e3);
 		return;

--- a/src/other.js
+++ b/src/other.js
@@ -983,11 +983,15 @@ function F_UPDATEUI(e) {
 		if (_UI.pSettings.pScanner.oHLReported.CHECKED) {
 			ForceHLAllSegments();
 			_RT.$HLlayer.setVisibility(true);
+			// Check the layer in layer switcher
+			$('#layer-switcher-item_wme_validator').prop('checked', true);
 		}
 		else {
 			ForceHLAllSegments();
 			destroyHLs();
 			_RT.$HLlayer.setVisibility(false);
+			// Uncheck the layer in layer switcher
+			$('#layer-switcher-item_wme_validator').prop('checked', false);
 		}
 		_RT.$switchValidator = false;
 	}


### PR DESCRIPTION
This fixes  the shortcut not working for us. There is a lot of code involved for adding the shortcut in a good way, so I propose using WazeWrap for add the shortcut.
Also for #59 this uses WazeWrap to add the layer to the layer selector, and toggles with the shortcut.