### PR TITLE
Fix false positive for "Same endpoints drivable segments" (78)

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -142,6 +142,10 @@ function deepCompare(obj1, obj2) {
 function getDirection(seg) {
 	return (seg.attributes.fwdDirection ? 1 : 0) + (seg.attributes.revDirection ? 2 : 0);
 };
+function reverseDirection(dir) {
+	// switch bit 0 and 1
+	return (dir << 1 | dir >> 1) & 3;
+};
 
 function getLocalizedValue(val, country) {
 	var ipu = OpenLayers.INCHES_PER_UNIT;

--- a/src/validate.js
+++ b/src/validate.js
@@ -2725,9 +2725,13 @@ function F_VALIDATE(disabledHL) {
 							&& nodeAID && nodeBID
 							&& (
 								(otherSegment.$nodeAID === nodeAID
-									&& otherSegment.$nodeBID === nodeBID)
+									&& otherSegment.$nodeBID === nodeBID
+									// and segments have common direction
+									&& otherSegment.$direction & direction)
 								|| (otherSegment.$nodeAID === nodeBID
-									&& otherSegment.$nodeBID === nodeAID)
+									&& otherSegment.$nodeBID === nodeAID
+									// and segments have common direction
+									&& otherSegment.$direction & reverseDirection(direction))
 							)
 						) {
 							// report either lower rank or longer segment


### PR DESCRIPTION
Report 78 only if you can get a route from junction A to junction B
through 2 "parallel" segments.

Fixes: #86