### PR TITLE
Fixes #92. Check for layer property before use.

### DIFF
--- a/doc/ChangeLog.txt
+++ b/doc/ChangeLog.txt
@@ -1,5 +1,8 @@
 Current changes:
 
+v
+- jangliss: Fix for layer refresh if layer did not trigger update
+
 v2019.08.13:
 - jangliss: Add lock checks for railroad and private roads
 

--- a/src/other.js
+++ b/src/other.js
@@ -59,6 +59,10 @@ function F_ONNODESCHANGED(e) {
  * On Change Layer Handler
  */
 function F_ONCHANGELAYER(e) {
+	// Trigger of layer change was not by a layer (ie WMETB Config Dialog)
+	if (!e.hasOwnProperty('layer')) {
+		return;
+	}
 	if (-1 !== e.layer.id.indexOf(GL_TBPREFIX)) {
 		if (!e.layer.visibility) {
 			for (var segmentID in WMo.segments.objects) {


### PR DESCRIPTION
If layer refresh is triggered by a non-layer update, for example Toolbox closing the config dialog, a JS exception would stop further processing of layers from happening.