### PR TITLE
Removed all references to modeController

### DIFF
--- a/meta/wme-externs.js
+++ b/meta/wme-externs.js
@@ -379,11 +379,6 @@ String.prototype.startsWith = function (a) { };
 // W Namespace
 var W = {
 	app: {
-		modeController: {
-			model: {
-				bind: function (a, b) { },
-			},
-		},
 		getAppRegionCode: function () { },
 	},
 	accelerators: {

--- a/src/other.js
+++ b/src/other.js
@@ -485,9 +485,6 @@ function F_INIT() {
 		"login": onLogin
 	});
 
-	// install event recovery
-	W.app.modeController.model.bind('change:mode', F_INIT);
-
 	// do login or wait for user
 	async(F_ONLOGIN);
 


### PR DESCRIPTION
Please note that I didn't actually build the project to try out whether everything still works. I merely quickly searched for all references to `W.app.modeController`, which will most likely be removed from the WME tomorrow if Waze puts the beta version to production as planned. Considering the limited changes, I figured that would be fine.