### PR TITLE
Adjust zoom levels to account for the new internal zoom levels

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -470,7 +470,7 @@ var SZ_PANEL_HEIGHT = 190;
  * Scan constants
  */
 /** @const */
-var SCAN_ZOOM = 5;
+var SCAN_ZOOM = 17;
 /** @const */
 var SCAN_STEP = 100;
 

--- a/src/other.js
+++ b/src/other.js
@@ -764,7 +764,7 @@ function F_UPDATEUI(e) {
 		}
 
 		// update start button
-		if (3 < WM.getZoom()) {
+		if (15 < WM.getZoom()) {
 			btns.bScan.CLASS = "btn btn-default";
 			btns.bScan.DISABLED = true;
 			btns.bScan.TITLE = trS("button.scan.tip.NA");
@@ -1099,7 +1099,7 @@ function F_UPDATEUI(e) {
 	if (RTStateIs(ST_STOP) && !_REP.$maxSeverity) {
 		// always display a zoom out message
 		if (!_UI.pMain.NODISPLAY) {
-			if (3 < WM.getZoom())
+			if (15 < WM.getZoom())
 				_RT.$curMessage = {
 					TEXT: _UI.pSettings.pScanner.oHLReported.CHECKED ?
 						trS("msg.pan.text")

--- a/src/validate.js
+++ b/src/validate.js
@@ -1667,7 +1667,7 @@ function F_VALIDATE(disabledHL) {
 		&& _RT.oReportToolbox.CHECKED;
 	var currentZoom = WM.getZoom();
 	var slowChecks = _UI.pSettings.pScanner.oSlowChecks.CHECKED
-		&& 3 < currentZoom;
+		&& 15 < currentZoom;
 	var oExcludeNotes = _UI.pMain.pFilter.oExcludeNotes.CHECKED;
 
 	var selectedObjects = [];
@@ -1829,7 +1829,7 @@ function F_VALIDATE(disabledHL) {
 		// mark segment as seen
 		_RT.$seen[segmentID] = seen = [0, null,
 			GL_TBCOLOR in rawSegment, GL_WMECHCOLOR in rawSegment,
-			isPartial || 4 > currentZoom,
+			isPartial || 16 > currentZoom,
 			cityID];
 
 		// increase city counter
@@ -3345,7 +3345,7 @@ function F_VALIDATE(disabledHL) {
 
 			// mark venue as seen
 			_RT.$seen[venueID] = seen = [0, null, false, false,
-				4 > currentZoom,
+				16 > currentZoom,
 				cityID];
 
 			// increase city counter


### PR DESCRIPTION
The WME has been updated to allow for the "standard" zoom levels. This is a preparation work to allow us to zoom out further in the future. All levels were incremented by 12 (e.g. level 3 has become 15). Permalinks still work as before, as the zoom parameter takes this difference into account. The zoomLevel parameter has become the new parameter to link to the "higher" zoom levels.

I've only done a quick search for "zoom" in the files and adjusted the constants to reflect these changes. I might have missed some stuff.