### PR TITLE
Introduce the new zoomLevel parameter in the permalink

### DIFF
--- a/src/report.js
+++ b/src/report.js
@@ -158,7 +158,7 @@ function F_SHOWREPORT(reportFormat) {
 			.transform(WM.projection, WM.displayProjection);
 		return window.location.origin
 			+ window.location.pathname
-			+ '?zoom=' + zoom
+			+ '?zoomLevel=' + zoom
 			+ '&lat=' + Math.round(c.lat * 1e5) / 1e5
 			+ '&lon=' + Math.round(c.lon * 1e5) / 1e5
 			+ '&env=' + nW.app.getAppRegionCode()
@@ -1142,7 +1142,7 @@ function F_SHOWREPORT(reportFormat) {
 		}
 		FR += window.location.origin;
 		FR += window.location.pathname;
-		FR += '?zoom=';
+		FR += '?zoomLevel=';
 		FR += z;
 		FR += '&lat=';
 		FR += obj.$objectCopy.$center.lat;


### PR DESCRIPTION
The changes to the zoom seem to have fixed the issues, according to an editor. But it seems I overlooked the permalink creation. The permalink structure expects to find the new zoom level in the new attribute `zoomLevel`. The existing `zoom` parameter continues to work the old way, so people are zoomed in way too much in the current version.